### PR TITLE
WIP: Adds option to set a custom service to subscribe to.

### DIFF
--- a/pyimc/actor.py
+++ b/pyimc/actor.py
@@ -18,6 +18,7 @@ class IMCBase:
         self._subs = {}  # type: Dict[Exception, List[types.MethodType]]
         self._port_imc = None  # type: int
         self._port_mc = None  # type: int
+        self.service_to_subscribe_to = None  # type: string
 
     def _start_subscriptions(self):
         # Add datagram endpoint for multicast announce
@@ -199,7 +200,7 @@ class ActorBase(IMCBase):
                 logging.warning('Multiple nodes are announcing the same IMC address or name: {} and {}'.format(key, key_imcadr))
 
             # New node
-            self.nodes[key] = IMCNode(msg)
+            self.nodes[key] = IMCNode(msg, self.service_to_subscribe_to)
 
         if not self.nodes[key].entities:
             q_ent = pyimc.EntityList()

--- a/pyimc/node.py
+++ b/pyimc/node.py
@@ -24,11 +24,15 @@ class IMCService:
 
 
 class IMCNode:
-    def __init__(self, announce=None):
+    def __init__(self, announce=None, service_to_subscribe_to = None):
         self.announce = None  # type: pyimc.Announce
         self.services = {}  # type: Dict[str, IMCService]
         self.entities = {}  # type: Dict[str, int]
         self.heartbeat = None  # type: float
+        self.service_to_subscribe_to = 'imc+udp' # Default service. Can be overridden.
+
+        if service_to_subscribe_to:
+            self.service_to_subscribe_to = service_to_subscribe_to
 
         if announce:
             self.update_announce(announce)
@@ -68,9 +72,9 @@ class IMCNode:
         :return: 
         """
         # TODO: Verify that UDP service exists, add TCP
-        imcudp_services = self.services['imc+udp']  # TODO: How to select interface if multiple imc services announced?
+        imcudp_services = self.services[self.service_to_subscribe_to]  # TODO: How to select interface if multiple imc services announced?
         if not imcudp_services:
-            logging.error('{} does not expose an imc+udp service'.format(self))
+            logging.error('{} does not expose an imc+udp+pylive service'.format(self))
             return
 
         # TODO: Try to determine which service to use, for now use first svc


### PR DESCRIPTION
Hi,

I would like the option to specify which service I would like to subscribe to in my actor. By using the functionality exposed in this (for now unmerged PR) https://github.com/LSTS/dune/pull/95, one can set up a seperate Transports.UDP with a service of e.g. imc+udp+pylive, which enables the python interface to only receive the messages it needs at a desired rate. 

An example usecase is raw sensor-data you would like the full data-rate stream, but do not want to bog down the link to CCUs such as Neptus. 

Consider this work-in-progres. This is functional, but needs some improvements:
 - Input on conventions and implementation strategy to fit in the pyimc project.
 - Give the correct error message in node.py when desired service is not provided.

Thanks,
Kristian
